### PR TITLE
feat: add contracts routes for operations on all contracts

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,4 @@
+NODE_ENV="development"
 MONGO_URL="required"
 MONGO_TEST_URL="required"
 MONGO_USERNAME="optional"
@@ -9,3 +10,6 @@ CATALOG_REGISTRY_URL="optional"
 SERVER_BASE_URL="optional"
 CATALOG_REGISTRY_URL="required"
 CATALOG_REGISTRY_FILE_EXT="required if CATALOG_REGISTRY_URL needs a file extension"
+
+# Authorizations from PTX services
+CATALOG_AUTHORIZATION_KEY="optional" # Authorization key for authorizing a verified catalog instance to make contract update requests

--- a/.github/workflows/run-unit-tests-on-pr.yml
+++ b/.github/workflows/run-unit-tests-on-pr.yml
@@ -15,6 +15,7 @@ jobs:
     env:
       CATALOG_REGISTRY_URL: https://raw.githubusercontent.com/Prometheus-X-association/reference-models/main/src/references/rules/
       CATALOG_REGISTRY_FILE_EXT: json
+      NODE_ENV: development
     steps:
     - uses: actions/checkout@v2
     - name: Set up Node.js

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "winston-mongodb": "^5.1.1"
   },
   "name": "contract",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "main": "src/start.ts",
   "scripts": {
     "gen-types": "npx mongoose-tsgen --config mtgen.config.json",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "winston-mongodb": "^5.1.1"
   },
   "name": "contract",
-  "version": "2.3.0",
+  "version": "2.2.0",
   "main": "src/start.ts",
   "scripts": {
     "gen-types": "npx mongoose-tsgen --config mtgen.config.json",

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -17,6 +17,9 @@ const REGISTRY_URL = process.env.CATALOG_REGISTRY_URL ?? '/rules/';
 const REGISTRY_FILE_EXT = process.env.CATALOG_REGISTRY_FILE_EXT;
 const REGISTRY_DEFINED = !!process.env.CATALOG_REGISTRY_URL;
 const SERVER_URL = process.env.SERVER_URL ?? 'http://localhost';
+const CATALOG_AUTHORIZATION_KEY =
+  process.env.CATALOG_AUTHORIZATION_KEY ?? false;
+
 export const config = {
   mongo: {
     url: MONGO_URL,
@@ -30,6 +33,7 @@ export const config = {
   },
   auth: {
     secret: SECRET_AUTH_KEY,
+    catalogKey: CATALOG_AUTHORIZATION_KEY,
   },
   session: {
     secret: SECRET_SESSION_KEY,

--- a/src/controllers/contracts.controller.ts
+++ b/src/controllers/contracts.controller.ts
@@ -1,0 +1,31 @@
+/// This controller is for processing demands that should act on all contracts instead of only "bilateral" or "ecosystem" contracts.
+
+import { Request, Response } from 'express';
+import bilateralService from 'services/bilateral.service';
+import contractService from 'services/contract.service';
+
+export const removeOfferingFromContracts = async (
+  req: Request,
+  res: Response,
+) => {
+  try {
+    const { offeringId } = req.params;
+
+    const [contractsRemoved, contractsModified] = await Promise.all([
+      contractService.removeOfferingFromContracts(offeringId),
+      bilateralService.deleteManyFromOffering(offeringId),
+    ]);
+
+    res.status(200).json({
+      message: 'Offering removed from contracts',
+      contractsModified,
+      contractsRemoved,
+    });
+  } catch (error: any) {
+    console.log(error);
+    res.status(500).json({
+      message: 'Failed to remove offering from contracts',
+      error: error.message,
+    });
+  }
+};

--- a/src/models/contract.model.ts
+++ b/src/models/contract.model.ts
@@ -109,4 +109,5 @@ const ContractSchema: Schema = new Schema(
     timestamps: true,
   },
 );
+
 export default mongoose.model<IContractDB>('Contract', ContractSchema);

--- a/src/routes/contracts.routes.ts
+++ b/src/routes/contracts.routes.ts
@@ -1,0 +1,13 @@
+/// Router for operations that should be performed on all kind of contracts
+
+import { removeOfferingFromContracts } from 'controllers/contracts.controller';
+import { Router } from 'express';
+
+const router: Router = Router();
+
+router.delete(
+  '/contracts/offerings/:offeringId',
+  removeOfferingFromContracts,
+);
+
+export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,7 @@ import mongoose from 'mongoose';
 import contractRoutes from 'routes/contract.routes';
 import bilateralContractRoutes from 'routes/bilateral.routes';
 import userRoutes from 'routes/user.routes';
+import contractsRoutes from 'routes/contracts.routes';
 import { logger } from 'utils/logger';
 import swaggerUi from 'swagger-ui-express';
 import swaggerJson from './swagger/swagger.json';
@@ -41,6 +42,20 @@ const startServer = async (url: string) => {
     );
     next();
   });
+
+  // TODO: This is a temporary solution since the catalog is the only
+  // entity that can act on contracts. But a proper layer of authorization
+  // should be implemented per participant.
+  router.use((req, res, next) => {
+    if (process.env.NODE_ENV !== 'development' && req.method !== 'GET') {
+      const authKey = req.headers['x-ptx-catalog-key'];
+      if (!authKey || authKey !== config.auth.catalogKey) {
+        return res.status(401).json({ message: 'Unauthorized' });
+      }
+    }
+    next();
+  });
+
   router.use(
     '/rules',
     express.static(path.join(__dirname, '..', 'public/rules')),
@@ -76,7 +91,7 @@ const startServer = async (url: string) => {
     }
     next();
   });
-  router.use('/', userRoutes, contractRoutes, bilateralContractRoutes);
+  router.use('/', userRoutes, contractRoutes, bilateralContractRoutes, contractsRoutes);
   router.use((req, res, next) => {
     const message = 'Route not found or incorrect method request!';
     const { method, url } = req;

--- a/src/services/bilateral.service.ts
+++ b/src/services/bilateral.service.ts
@@ -373,6 +373,27 @@ export class BilateralContractService {
     }
   }
 
+  /**
+   * Removes all bilateral contracts associated with a service offering.
+   * This comes in handy when a service offering is deleted on a catalog and
+   * we want existing contracts to be deleted as well.
+   */
+  public async deleteManyFromOffering(serviceOfferingId: string) {
+    try {
+      const deleted = await BilateralContract.deleteMany({
+        $or: [
+          { serviceOffering: serviceOfferingId },
+          { 'purpose.purpose': { $in: [serviceOfferingId] } },
+        ],
+      });
+
+      return deleted.deletedCount;
+    } catch (error) {
+      logger.error('[bilateral/Service, deleteFromOffering]:', error);
+      throw error;
+    }
+  }
+
   private convertContract(contract: IBilateralContractDB): any {
     return {};
   }

--- a/src/tests/bilateral.crud.test.ts
+++ b/src/tests/bilateral.crud.test.ts
@@ -277,4 +277,14 @@ describe('CRUD test cases for Bilateral Contracts.', () => {
     // Check if the 'status' field is set to 'revoked'
     expect(response.body.status).to.equal('revoked');
   });
+
+  it('should remove a bilateral contract using a service offering ID', async () => {
+    // Reuse the service offering ID from the contract created in the first test
+    const serviceOfferingId = 'offering';
+
+    // Should throw an error when failing
+    await bilateralContractService.deleteManyFromOffering(serviceOfferingId);
+
+    expect(true).to.equal(true);
+  });
 });

--- a/src/tests/contracts.offerings.test.ts
+++ b/src/tests/contracts.offerings.test.ts
@@ -1,0 +1,86 @@
+import supertest from 'supertest';
+import app from 'server';
+import Contract from 'models/contract.model';
+import Bilateral from 'models/bilateral.model';
+import { config } from 'config/config';
+import bilateralService from 'services/bilateral.service';
+import { IBilateralContract } from 'interfaces/contract.interface';
+import { expect } from 'chai';
+import contractService from 'services/contract.service';
+
+const SERVER_PORT = 9999;
+describe('Operations on offerings in contracts', () => {
+  let server: any;
+  let authTokenCookie: any;
+  const serviceOfferingId: string = 'serviceOfferingId';
+
+  before(async () => {
+    server = await app.startServer(config.mongo.testUrl);
+    await new Promise((resolve) => {
+      server.listen(SERVER_PORT, () => {
+        console.log(`Test server is running on port ${SERVER_PORT}`);
+        resolve(true);
+      });
+    });
+
+    await Contract.deleteMany({});
+    await Bilateral.deleteMany({});
+
+    const authResponse = await supertest(app.router).get('/ping');
+    authTokenCookie = authResponse.headers['set-cookie'];
+
+    console.log('Setting up bilateral & ecosystem contracts with a serviceOffering')
+
+    // Create a bilateral contract
+    const contractData: Partial<IBilateralContract> = {
+      dataProvider: 'provider',
+      dataConsumer: 'consumer',
+      serviceOffering: serviceOfferingId,
+    };
+
+    await bilateralService.genContract(contractData as any);
+
+    // Create a ecosystem contract
+    const contract = {
+      '@context': 'http://www.w3.org/ns/odrl/2/',
+      '@type': 'Offer',
+      permission: [
+        {
+          action: 'read',
+          target: 'http://contract-target/policy',
+        },
+        {
+          action: 'use',
+          target: 'http://contract-target/service',
+        },
+      ],
+      serviceOfferings: [
+        {
+          participant: 'provider',
+          serviceOffering: serviceOfferingId,
+          policies: [],
+        },
+      ],
+    };
+
+    await contractService.genContract(contract as any);
+  });
+
+  after(async () => {
+    // Stop the test server
+    server.close();
+    console.log('Test server stopped.');
+  });
+
+  it('should remove provided service offering from contracts', async () => {
+    // Send a DELETE request to remove the service offering
+    const response = await supertest(app.router)
+      .delete(`/contracts/offerings/${serviceOfferingId}`)
+      .set('Cookie', authTokenCookie);
+
+    // Check the response
+    expect(response.status).to.equal(200);
+    expect(response.body.contractsModified).to.not.equal(0);
+    expect(response.body.contractsRemoved).to.not.equal(0);
+  })
+});


### PR DESCRIPTION
The contracts routes will be used to perform operations that cover more than just a single type of contract. The first implementation is to ensure when a serviceoffering is removed from the catalog, all contracts that have that service offering are also altered (or removed for bilateral ones).

## Feat
- Add new router for contracts (plural)
- Add route to alter / remove contracts based on a provided service offering
- Add service methods for bilateral contract to handle contract deletion on service offering removal (this should be expanded upon in a later update when service offerings will not be referenced but flattened out in the contract to "archive" the contract instead of removing it. The current implementation forces the deletion as otherwise, the referenced service offering link will be broken once deleted from the catalogue.)
- Add service method for ecosystem contracts to handle offering removal of the service offering list & the policies.

## Security Addition
Since the catalog is today the only one communicating with the Contract Service and that it is lacking a proper authentication mecanism (such as participant registration for example), it was decided to add a `x-ptx-catalog-key` header when not in development to validate all non GET requests. This ensures:
- Keeping compatibility with the PTX connector using GET endpoints with no auth
- Protecting all contract alteration operations to be restricted to trusted catalogs that are aware of the `x-ptx-catalog-key`

### Env addition
This new security addition comes with the addition of 2 env vars
|var|why it was added|
|-|-|
|`NODE_ENV`|To control the environment of the application, since setting NODE_ENV=development will bypass the authorization check|
|`CATALOG_AUTHORIZATION_KEY`|Value expected for the `x-ptx-catalog-key` header to authorize non GET requests|