### PR TITLE
fix: set env path as otherwise server might not read it properly

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,6 +1,7 @@
 import dotenv from 'dotenv';
+import path from 'path';
 
-dotenv.config();
+dotenv.config({ path: path.join(__dirname, '..', '..', '.env') });
 
 const MONGO_USERNAME = process.env.MONGO_USERNAME ?? '';
 const MONGO_PASSWORD = process.env.MONGO_PASSWORD ?? '';


### PR DESCRIPTION
## Fix
- Set .env path in config as without it, some servers fail to properly load the .env configuration