### PR TITLE
Add dataprocessing chains

### DIFF
--- a/src/controllers/contract.controller.ts
+++ b/src/controllers/contract.controller.ts
@@ -359,6 +359,28 @@ export const getDataProcessings = async (req: Request, res: Response) => {
   }
 };
 
+export const getDataProcessingsByParticipant = async (req: Request, res: Response) => {
+  try {
+    const contractId: string = req.params.id;
+    const participant: string = req.query.participant as string;
+    if (!participant) {
+      return res.status(400).json({ error: 'Participant base 64 encoded query parameter is required.' });
+    }
+    const decodedParticipant = Buffer.from(participant, 'base64').toString('utf-8');
+    const dataProcessings =
+      await contractService.getDataProcessingsByParticipant(contractId, decodedParticipant);
+    if (!dataProcessings) {
+      return res.json([]);
+    }
+    return res.json(dataProcessings);
+  } catch (error) {
+    logger.error('Error retrieving the data processings:', error);
+    res
+      .status(500)
+      .json({ error: 'An error occurred while retrieving data processings.' });
+  }
+};
+
 export const writeDataProcessings = async (req: Request, res: Response) => {
   try {
     const contractId: string = req.params.id;
@@ -368,13 +390,13 @@ export const writeDataProcessings = async (req: Request, res: Response) => {
       processings,
     );
     if (!dataProcessings) {
-      throw new Error('something went wrong while updating data processings');
+      throw new Error('something went wrong while writing data processings');
     }
     return res.json(dataProcessings);
   } catch (error) {
-    logger.error('Error while updating data processings:', error);
+    logger.error('Error while writing data processings:', error);
     res.status(500).json({
-      error: 'An error occurred while while updating data processings.',
+      error: 'An error occurred while while writing data processings.',
     });
   }
 };
@@ -395,17 +417,19 @@ export const insertDataProcessing = async (req: Request, res: Response) => {
   } catch (error) {
     logger.error('Error while inserting data processing:', error);
     res.status(500).json({
-      error: 'An error occurred while while inserting data processing.',
+      error: 'An error occurred while inserting data processing.',
     });
   }
 };
 
 export const updateDataProcessing = async (req: Request, res: Response) => {
   try {
-    const contractId: string = req.params.id;
+    const { id: contractId, processingId } = req.params;
     const processing = req.body;
+    console.log('processingId', processingId);
     const dataProcessings = await contractService.updateDataProcessing(
       contractId,
+      processingId,
       processing,
     );
     if (!dataProcessings) {
@@ -422,10 +446,10 @@ export const updateDataProcessing = async (req: Request, res: Response) => {
 
 export const removeDataProcessing = async (req: Request, res: Response) => {
   try {
-    const { id: contractId, index } = req.params;
+    const { id: contractId, processingId } = req.params;
     const dataProcessings = await contractService.removeDataProcessing(
       contractId,
-      +index,
+      processingId,
     );
     if (!dataProcessings) {
       throw new Error('something went wrong while deleting data processing');

--- a/src/interfaces/schemas.interface.ts
+++ b/src/interfaces/schemas.interface.ts
@@ -856,6 +856,37 @@ export type ContractRevokedMember = {
 };
 
 /**
+ * Lean version of ContractDataProcessingDocument
+ *
+ * This has all Mongoose getters & functions removed. This type will be returned from `ContractDocument.toObject()`.
+ * ```
+ * const contractObject = contract.toObject();
+ * ```
+ */
+export type ContractDataProcessing = {
+  provider: string;
+  consumer: string;
+  infrastructureServices: ContractInfrastructureService[];
+  status: 'active' | 'inactive';
+};
+
+
+/**
+ * Lean version of ContractInfrastructureServicesDocument
+ *
+ * This has all Mongoose getters & functions removed. This type will be returned from `ContractDocument.toObject()`.
+ * ```
+ * const contractObject = contract.toObject();
+ * ```
+ */
+export type ContractInfrastructureService = {
+    participant: string;
+    serviceOffering: string;
+    configParams?: { [key: string]: any };
+};
+
+
+/**
  * Lean version of ContractDocument
  *
  * This has all Mongoose getters & functions removed. This type will be returned from `ContractDocument.toObject()`. To avoid conflicts with model names, use the type alias `ContractObject`.
@@ -870,7 +901,7 @@ export type Contract = {
   orchestrator?: string;
   serviceOfferings: ContractServiceOffering[];
   rolesAndObligations: ContractRolesAndObligation[];
-  dataProcessings: string[];
+  dataProcessings: ContractDataProcessing[];
   purpose: ContractPurpose[];
   members: ContractRevokedMember[];
   revokedMembers: ContractRevokedMember[];
@@ -1240,6 +1271,29 @@ export type ContractRevokedMemberDocument = mongoose.Types.Subdocument & {
 };
 
 /**
+ * Mongoose Subdocument type
+ *
+ * Type of `ContractDocument["dataProcessings"]` element.
+ */
+export type ContractDataProcessingDocument = mongoose.Types.Subdocument & {
+    provider: string;
+    consumer: string;
+    infrastructureServices: mongoose.Types.DocumentArray<ContractInfrastructureServiceDocument>;
+    status: 'active' | 'inactive';
+};
+
+/**
+ * Mongoose Subdocument type
+ *
+ * Type of `ContractDocument["dataProcessings"]["infrastructureServices"]` element.
+ */
+export type ContractInfrastructureServiceDocument = mongoose.Types.Subdocument & {
+  participant: string;
+  serviceOffering: string;
+  configParams?: { [key: string]: any };
+};
+
+/**
  * Mongoose Document type
  *
  * Pass this type to the Mongoose Model constructor:
@@ -1258,7 +1312,7 @@ export type ContractDocument = mongoose.Document<
     orchestrator?: string;
     serviceOfferings: mongoose.Types.DocumentArray<ContractServiceOfferingDocument>;
     rolesAndObligations: mongoose.Types.DocumentArray<ContractRolesAndObligationDocument>;
-    dataProcessings: mongoose.Types.Array<string>;
+    dataProcessings: mongoose.Types.DocumentArray<ContractDataProcessingDocument>;
     purpose: mongoose.Types.DocumentArray<ContractPurposeDocument>;
     members: mongoose.Types.DocumentArray<ContractRevokedMemberDocument>;
     revokedMembers: mongoose.Types.DocumentArray<ContractRevokedMemberDocument>;

--- a/src/models/contract.model.ts
+++ b/src/models/contract.model.ts
@@ -84,6 +84,23 @@ const MemberSchema = new Schema(
   },
   { _id: false },
 );
+
+const InfrastructureServiceSchema = new Schema({
+  participant: { type: String, required: true },
+  serviceOffering: { type: String, required: true },
+});
+
+const DataProcessingSchema = new Schema({
+    provider: { type: String, required: true },
+    consumer: { type: String, required: true },
+    infrastructureServices: { type: [InfrastructureServiceSchema], default: [] },
+    status: {
+      type: String,
+      enum: ['active', 'inactive'],
+      default: 'active',
+    },
+});
+
 const ContractSchema: Schema = new Schema(
   {
     uid: String,
@@ -92,7 +109,7 @@ const ContractSchema: Schema = new Schema(
     orchestrator: String,
     serviceOfferings: [OfferingSchema],
     rolesAndObligations: [{ role: String, policies: [PolicySchema] }],
-    dataProcessings: { type: [String], default: [] },
+    dataProcessings: { type: [DataProcessingSchema], default: [] },
     purpose: [PurposeSchema],
     members: [MemberSchema],
     revokedMembers: [MemberSchema],

--- a/src/routes/contract.routes.ts
+++ b/src/routes/contract.routes.ts
@@ -21,6 +21,7 @@ import {
   removeDataProcessing,
   updateDataProcessing,
   deleteDataProcessing,
+  getDataProcessingsByParticipant,
 } from '../controllers/contract.controller';
 import { check } from 'express-validator';
 import { logPayloadMiddleware } from 'middlewares/logPayload.middleware';
@@ -61,16 +62,18 @@ router.delete(
 );
 
 // List the data processings within the chain available on the contrat
-router.get('/contracts/processings/:id', getDataProcessings);
+router.get('/contracts/:id/processings', getDataProcessings);
 // Add the data processing chain to the contract
-router.post('/contracts/processings/:id', writeDataProcessings);
+router.post('/contracts/:id/processings', writeDataProcessings);
 // Insert a new data processing inside the chain at a specific given index
-router.put('/contracts/processings/insert/:id/:index', insertDataProcessing);
+router.put('/contracts/:id/processings/insert/:index', insertDataProcessing);
 // Update a specific data processing from the chain
-router.put('/contracts/processings/update/:id', updateDataProcessing);
+router.put('/contracts/:id/processings/update/:processingId', updateDataProcessing);
 // Remove a specific data processing from the chain
-router.delete('/contracts/processings/:id', deleteDataProcessing);
+router.delete('/contracts/:id/processings/:processingId', deleteDataProcessing);
 // Remove a specific data processing from the chain by index
-router.delete('/contracts/processings/:id/:index', removeDataProcessing);
+router.delete('/contracts/:id/processings/:processingId', removeDataProcessing);
+// Get the data processing by participant
+router.get('/contracts/:id/processings/participant', getDataProcessingsByParticipant);
 
 export default router;


### PR DESCRIPTION
## Changes
Modifications have been made to support multiple data processing operations defined by the orchestrator within the contract, rather than a single data processing operation that applies to all exchanges.

## Feature
- Added provider, consumer, and infrastructureServices to dataProcessings, and removed participant and serviceOffering.
- Introduced an infrastructureService subdocument.
- Added tests.
- Added routes to retrieve all dataProcessingChains by contract and by participant.
- Introduced a status for dataProcessing to allow tracking of modifications and history.